### PR TITLE
Unicode data for tag rules without flowdock-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,3 @@ Tests are run with npm:
 npm install
 npm test
 ```
-
-## TODO
-
-- customise rendering
-- remove flowdock-text as dependency

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "markdown-it-testgen": "^0.1.4",
     "mocha": "^2.2.5",
     "regenerate": "^1.2.1",
-    "request": "^2.57.0",
     "unicode-7.0.0": "^0.1.5"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -23,14 +23,12 @@
     "test": "mocha --compilers js:babel/register"
   },
   "devDependencies": {
-    "babel": "^5.4.7",
-    "markdown-it": "^4.2.1",
+    "babel": "^5.5.8",
+    "markdown-it": "^4.2.2",
     "markdown-it-testgen": "^0.1.4",
     "mocha": "^2.2.5",
-    "request": "^2.57.0"
-  },
-  "dependencies": {
     "regenerate": "^1.2.1",
+    "request": "^2.57.0",
     "unicode-7.0.0": "^0.1.5"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
-    "prepublish": "babel --modules common src --out-dir dist",
+    "prepublish": "babel --modules common src --out-dir dist && babel-node support/unicode.js",
     "test": "mocha --compilers js:babel/register"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "request": "^2.57.0"
   },
   "dependencies": {
-    "flowdock-text": "^1.2.0"
+    "regenerate": "^1.2.1",
+    "unicode-7.0.0": "^0.1.5"
   },
   "directories": {
     "test": "test"

--- a/src/hashtag.js
+++ b/src/hashtag.js
@@ -1,5 +1,5 @@
-import FlowdockText from 'flowdock-text'
-import parser from './parser'
+import {tagEnd, tagCharacter} from './unicode';
+import parser from './parser';
 
 function flowdockHashtag(tokens, idx) {
   var tag = tokens[idx].content;
@@ -8,7 +8,9 @@ function flowdockHashtag(tokens, idx) {
 }
 
 export default function(md, options) {
-  const hashtag = parser(md, 'hashtag', /#|＃/, FlowdockText.regexen.autoLinkHashtags);
+  const split = "#|＃";
+  const regex = new RegExp("(?:^|$|[^" + tagEnd.slice(1) + ")((?:" + split + ")(?:" + tagCharacter + ")*(?:" + tagEnd + ")+)", "g");
+  const hashtag = parser(md, 'hashtag', new RegExp(split), regex);
   md.core.ruler.push('hashtag', hashtag);
   md.renderer.rules.hashtag = flowdockHashtag;
 };

--- a/src/hashtag.js
+++ b/src/hashtag.js
@@ -1,4 +1,3 @@
-import {tagEnd, tagCharacter} from './unicode';
 import parser from './parser';
 
 function flowdockHashtag(tokens, idx) {
@@ -9,8 +8,7 @@ function flowdockHashtag(tokens, idx) {
 
 export default function(md, options) {
   const split = "#|＃";
-  const regex = new RegExp("(?:^|$|[^" + tagEnd.slice(1) + ")((?:" + split + ")(?:" + tagCharacter + ")*(?:" + tagEnd + ")+)", "g");
-  const hashtag = parser(md, 'hashtag', new RegExp(split), regex);
+  const hashtag = parser(md, 'hashtag', new RegExp(split));
   md.core.ruler.push('hashtag', hashtag);
   md.renderer.rules.hashtag = flowdockHashtag;
 };

--- a/src/mention.js
+++ b/src/mention.js
@@ -1,4 +1,3 @@
-import {tagEnd, tagCharacter} from './unicode';
 import parser from './parser';
 
 function flowdockMention(tokens, idx) {
@@ -9,8 +8,7 @@ function flowdockMention(tokens, idx) {
 
 export default function(md, options) {
   const split = "@|＠";
-  const regex = new RegExp("(?:^|$|[^" + tagEnd.slice(1) + ")((?:" + split + ")(?:" + tagCharacter + ")*(?:" + tagEnd + ")+)", "g");
-  const mention = parser(md, 'mention', new RegExp(split), regex);
+  const mention = parser(md, 'mention', new RegExp(split));
   md.core.ruler.push('mention', mention);
   md.renderer.rules.mention = flowdockMention;
 };

--- a/src/mention.js
+++ b/src/mention.js
@@ -1,5 +1,5 @@
-import FlowdockText from 'flowdock-text'
-import parser from './parser'
+import {tagEnd, tagCharacter} from './unicode';
+import parser from './parser';
 
 function flowdockMention(tokens, idx) {
   var tag = tokens[idx].content;
@@ -8,7 +8,9 @@ function flowdockMention(tokens, idx) {
 }
 
 export default function(md, options) {
-  const mention = parser(md, 'mention', /@|＠/, FlowdockText.regexen.autoLinkMentions);
+  const split = "@|＠";
+  const regex = new RegExp("(?:^|$|[^" + tagEnd.slice(1) + ")((?:" + split + ")(?:" + tagCharacter + ")*(?:" + tagEnd + ")+)", "g");
+  const mention = parser(md, 'mention', new RegExp(split), regex);
   md.core.ruler.push('mention', mention);
   md.renderer.rules.mention = flowdockMention;
 };

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,3 +1,11 @@
+import {tagEnd, tagCharacter} from './unicode';
+
+function not(group) { return "[^" + group.slice(1); }
+
+function matcher(boundary, body, end) {
+  return new RegExp("(?:^|$|" + not(end) + ")((?:" + boundary + ")(?:" + body + ")*(?:" + end + ")+)", "g");
+};
+
 function split(currentToken, boundary, regex, Token, name) {
   // find tokens matching regex
   var text = currentToken.content;
@@ -38,8 +46,9 @@ function split(currentToken, boundary, regex, Token, name) {
   return nodes;
 }
 
-export default function(md, name, boundary, regex) {
+export default function(md, name, boundary) {
   const arrayReplaceAt = md.utils.arrayReplaceAt;
+  const regex = matcher(boundary.source, tagCharacter, tagEnd);
 
   return function parser(state) {
     const blockTokens = state.tokens;

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -1,3 +1,4 @@
+/* The regexes are automatically compiled during prepublish */
 import regenerate from 'regenerate';
 
 const tagBody = regenerate()

--- a/src/unicode.js
+++ b/src/unicode.js
@@ -1,0 +1,11 @@
+import regenerate from 'regenerate';
+
+const tagBody = regenerate()
+  .add(require('unicode-7.0.0/categories/L/code-points'))
+  .add(require('unicode-7.0.0/categories/M/code-points'))
+  .add(require('unicode-7.0.0/categories/N/code-points'))
+  .add(require('unicode-7.0.0/categories/Pc/code-points'))
+  .add(require('unicode-7.0.0/categories/Pd/code-points'));
+
+export const tagEnd = tagBody.toString();
+export const tagCharacter = tagBody.add(".").toString();

--- a/support/unicode.js
+++ b/support/unicode.js
@@ -1,0 +1,8 @@
+import * as fs from 'fs';
+import * as unicode from '../src/unicode';
+const data = `
+// Automatically compiled with support/unicode.js
+module.exports = ${JSON.stringify(unicode)};
+`
+
+fs.writeFileSync('dist/unicode.js', data)


### PR DESCRIPTION
Replace flowdock-text with Unicode categories. The implementation should be portable to other platforms and perhaps a bit easier to work with. As Unicode data is quite large, we don't want to ship it to clients. Instead, just the generated regexen is compiled into distribution.
