### PR TITLE
Fix README.md `require` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install markdown-it-flowdock --save
 ```
 
 ```js
-var md = require('markdown-it')().use(require('markdown-it-diaspora-flowdock'));
+var md = require('markdown-it')().use(require('markdown-it-flowdock'));
 md.render('Test #hahstag @user'); // => 'Test <a class="hashtag">#hashtag</a> <a class="mention">@user</a>'
 ```
 


### PR DESCRIPTION
- ...`diaspora-`... doesn't appear to exist anywhere in the code base and it's not the packages current name. Remove this text so potential new users aren't confused as to its usage.
